### PR TITLE
Updated the maven plugins for android and gwt as build was failing with prev versions

### DIFF
--- a/demo/calc-engine-android-demo/pom.xml
+++ b/demo/calc-engine-android-demo/pom.xml
@@ -48,8 +48,9 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
-                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
-                <artifactId>android-maven-plugin</artifactId>
+                <groupId>com.simpligility.maven.plugins</groupId>
+        <artifactId>android-maven-plugin</artifactId>
+        <version>4.3.0</version> <!-- use latest release -->
                 <extensions>true</extensions>
                 <configuration>
                     <!--<extractDuplicates>true</extractDuplicates>-->

--- a/demo/calc-engine-android-demo/src/main/AndroidManifest.xml
+++ b/demo/calc-engine-android-demo/src/main/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="18" />
+        android:minSdkVersion="10"
+        android:targetSdkVersion="23" />
 
     <application
         android:allowBackup="true"

--- a/demo/calc-engine-objectivec-demo/Makefile
+++ b/demo/calc-engine-objectivec-demo/Makefile
@@ -5,7 +5,7 @@ SOURCE_DIR = ../../calc-engine-core/src/main/java
 JAVA_SOURCES = sources.list
 
 # Change to where distribution was unzipped.
-J2OBJC_DISTRIBUTION = /Users/DidierGirard/softs/j2objc-0.8.8
+J2OBJC_DISTRIBUTION = /Users/preetam/Documents/java_to_objc/j2objc-1.0.2
 J2OBJC = $(J2OBJC_DISTRIBUTION)/j2objc
 J2OBJCC = $(J2OBJC_DISTRIBUTION)/j2objcc
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <gwt.version>2.5.1</gwt.version>
-        <gwt.maven.version>2.5.1</gwt.maven.version>
+        <gwt.version>2.6.0</gwt.version>
+        <gwt.maven.version>2.6.0</gwt.maven.version>
         <android.api.version>4.1.1.4</android.api.version>
         <junit.version>4.10</junit.version>
-        <android.platform>19</android.platform>
+        <android.platform>23</android.platform>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
1. Upgraded the maven plugins for gwt and android
2. J2OBJC_DISTRIBUTION environment variable was not considered while `make` was run in the Objective-C code. Had to specify the local path of the j2objc dir in the makefile.
